### PR TITLE
feat: fit benthos into soda deployments

### DIFF
--- a/.github/workflows/docker_edge.yml
+++ b/.github/workflows/docker_edge.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.repository == 'benthosdev/benthos' || github.event_name != 'schedule' }}
+    if: ${{ github.repository == 'benthosdev/benthos' }}
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   integration-test:
-    if: ${{ github.repository == 'benthosdev/benthos' || github.event_name != 'schedule' }}
+    if: ${{ github.repository == 'benthosdev/benthos' }}
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,27 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
 
+    # Authenticates against google cloud using OIDC connector
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v1'
+      with:
+        workload_identity_provider: 'projects/1035679941503/locations/global/workloadIdentityPools/github-actions-ci/providers/github-actions'
+        service_account: 'github-actions-benthos@artifacts-321215.iam.gserviceaccount.com'
+
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v1'
+      with:
+        version: 408.0.0
+
+    - name: auth to gcr 
+      run: gcloud auth configure-docker us-docker.pkg.dev -q
+
     - name: Docker meta CGO
       id: docker_meta_cgo
       uses: crazy-max/ghaction-docker-meta@v2
       with:
-        images: jeffail/benthos
+        images: sodahealth/benthos
         flavor: |
           latest=auto
           suffix=-cgo
@@ -113,7 +129,7 @@ jobs:
       id: docker_meta
       uses: crazy-max/ghaction-docker-meta@v2
       with:
-        images: jeffail/benthos
+        images: sodahealth/benthos
         tags: |
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cross-build:
-    if: ${{ github.repository == 'benthosdev/benthos' || github.event_name != 'schedule' }}
+    if: ${{ github.repository == 'benthosdev/benthos' }}
     strategy:
       fail-fast: false
       matrix:

--- a/internal/codec/reader_test.go
+++ b/internal/codec/reader_test.go
@@ -476,8 +476,8 @@ func TestCSVGzipReaderOld(t *testing.T) {
 
 func TestCSVSkipBOMReader(t *testing.T) {
 	// https://en.wikipedia.org/wiki/Byte_order_mark
-	bom := []byte{0xef, 0xbb, 0xbf}
-	data := append(bom, []byte("col1,col2,col3\nfoo1,bar1,baz1\nfoo2,bar2,baz2\nfoo3,bar3,baz3")...)
+	data := []byte{0xef, 0xbb, 0xbf}
+	data = append(data, []byte("col1,col2,col3\nfoo1,bar1,baz1\nfoo2,bar2,baz2\nfoo3,bar3,baz3")...)
 	testReaderSuite(
 		t, "skipbom/csv", "", data,
 		`{"col1":"foo1","col2":"bar1","col3":"baz1"}`,

--- a/website/docs/components/inputs/aws_s3.md
+++ b/website/docs/components/inputs/aws_s3.md
@@ -241,11 +241,13 @@ Default: `"all-bytes"`
 | `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv:x` | Consume structured rows as values separated by a custom delimiter, the first row must be a header row. The custom delimiter must be a single character, e.g. the codec `"csv:\t"` would consume a tab delimited file. |
+| `csv-safe` | Consume structured rows like `csv`, but sends messages with empty maps on failure to parse. Includes row number and parsing errors (if any) in the message's metadata. |
 | `delim:x` | Consume the file in segments divided by a custom delimiter. |
 | `gzip` | Decompress a gzip file, this codec should precede another codec, e.g. `gzip/all-bytes`, `gzip/tar`, `gzip/csv`, etc. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `multipart` | Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch. |
 | `regex:(?m)^\d\d:\d\d:\d\d` | Consume the file in segments divided by regular expression. |
+| `skipbom` | Skip a byte order mark |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 
 

--- a/website/docs/components/inputs/azure_blob_storage.md
+++ b/website/docs/components/inputs/azure_blob_storage.md
@@ -155,11 +155,13 @@ Default: `"all-bytes"`
 | `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv:x` | Consume structured rows as values separated by a custom delimiter, the first row must be a header row. The custom delimiter must be a single character, e.g. the codec `"csv:\t"` would consume a tab delimited file. |
+| `csv-safe` | Consume structured rows like `csv`, but sends messages with empty maps on failure to parse. Includes row number and parsing errors (if any) in the message's metadata. |
 | `delim:x` | Consume the file in segments divided by a custom delimiter. |
 | `gzip` | Decompress a gzip file, this codec should precede another codec, e.g. `gzip/all-bytes`, `gzip/tar`, `gzip/csv`, etc. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `multipart` | Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch. |
 | `regex:(?m)^\d\d:\d\d:\d\d` | Consume the file in segments divided by regular expression. |
+| `skipbom` | Skip a byte order mark |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 
 

--- a/website/docs/components/inputs/file.md
+++ b/website/docs/components/inputs/file.md
@@ -90,11 +90,13 @@ Default: `"lines"`
 | `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv:x` | Consume structured rows as values separated by a custom delimiter, the first row must be a header row. The custom delimiter must be a single character, e.g. the codec `"csv:\t"` would consume a tab delimited file. |
+| `csv-safe` | Consume structured rows like `csv`, but sends messages with empty maps on failure to parse. Includes row number and parsing errors (if any) in the message's metadata. |
 | `delim:x` | Consume the file in segments divided by a custom delimiter. |
 | `gzip` | Decompress a gzip file, this codec should precede another codec, e.g. `gzip/all-bytes`, `gzip/tar`, `gzip/csv`, etc. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `multipart` | Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch. |
 | `regex:(?m)^\d\d:\d\d:\d\d` | Consume the file in segments divided by regular expression. |
+| `skipbom` | Skip a byte order mark |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 
 

--- a/website/docs/components/inputs/gcp_cloud_storage.md
+++ b/website/docs/components/inputs/gcp_cloud_storage.md
@@ -116,11 +116,13 @@ Default: `"all-bytes"`
 | `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv:x` | Consume structured rows as values separated by a custom delimiter, the first row must be a header row. The custom delimiter must be a single character, e.g. the codec `"csv:\t"` would consume a tab delimited file. |
+| `csv-safe` | Consume structured rows like `csv`, but sends messages with empty maps on failure to parse. Includes row number and parsing errors (if any) in the message's metadata. |
 | `delim:x` | Consume the file in segments divided by a custom delimiter. |
 | `gzip` | Decompress a gzip file, this codec should precede another codec, e.g. `gzip/all-bytes`, `gzip/tar`, `gzip/csv`, etc. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `multipart` | Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch. |
 | `regex:(?m)^\d\d:\d\d:\d\d` | Consume the file in segments divided by regular expression. |
+| `skipbom` | Skip a byte order mark |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 
 

--- a/website/docs/components/inputs/http_client.md
+++ b/website/docs/components/inputs/http_client.md
@@ -752,11 +752,13 @@ Requires version 3.42.0 or newer
 | `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv:x` | Consume structured rows as values separated by a custom delimiter, the first row must be a header row. The custom delimiter must be a single character, e.g. the codec `"csv:\t"` would consume a tab delimited file. |
+| `csv-safe` | Consume structured rows like `csv`, but sends messages with empty maps on failure to parse. Includes row number and parsing errors (if any) in the message's metadata. |
 | `delim:x` | Consume the file in segments divided by a custom delimiter. |
 | `gzip` | Decompress a gzip file, this codec should precede another codec, e.g. `gzip/all-bytes`, `gzip/tar`, `gzip/csv`, etc. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `multipart` | Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch. |
 | `regex:(?m)^\d\d:\d\d:\d\d` | Consume the file in segments divided by regular expression. |
+| `skipbom` | Skip a byte order mark |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 
 

--- a/website/docs/components/inputs/sftp.md
+++ b/website/docs/components/inputs/sftp.md
@@ -166,11 +166,13 @@ Default: `"all-bytes"`
 | `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv:x` | Consume structured rows as values separated by a custom delimiter, the first row must be a header row. The custom delimiter must be a single character, e.g. the codec `"csv:\t"` would consume a tab delimited file. |
+| `csv-safe` | Consume structured rows like `csv`, but sends messages with empty maps on failure to parse. Includes row number and parsing errors (if any) in the message's metadata. |
 | `delim:x` | Consume the file in segments divided by a custom delimiter. |
 | `gzip` | Decompress a gzip file, this codec should precede another codec, e.g. `gzip/all-bytes`, `gzip/tar`, `gzip/csv`, etc. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `multipart` | Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch. |
 | `regex:(?m)^\d\d:\d\d:\d\d` | Consume the file in segments divided by regular expression. |
+| `skipbom` | Skip a byte order mark |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 
 

--- a/website/docs/components/inputs/socket.md
+++ b/website/docs/components/inputs/socket.md
@@ -95,11 +95,13 @@ Requires version 3.42.0 or newer
 | `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv:x` | Consume structured rows as values separated by a custom delimiter, the first row must be a header row. The custom delimiter must be a single character, e.g. the codec `"csv:\t"` would consume a tab delimited file. |
+| `csv-safe` | Consume structured rows like `csv`, but sends messages with empty maps on failure to parse. Includes row number and parsing errors (if any) in the message's metadata. |
 | `delim:x` | Consume the file in segments divided by a custom delimiter. |
 | `gzip` | Decompress a gzip file, this codec should precede another codec, e.g. `gzip/all-bytes`, `gzip/tar`, `gzip/csv`, etc. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `multipart` | Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch. |
 | `regex:(?m)^\d\d:\d\d:\d\d` | Consume the file in segments divided by regular expression. |
+| `skipbom` | Skip a byte order mark |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 
 

--- a/website/docs/components/inputs/socket_server.md
+++ b/website/docs/components/inputs/socket_server.md
@@ -105,11 +105,13 @@ Requires version 3.42.0 or newer
 | `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv:x` | Consume structured rows as values separated by a custom delimiter, the first row must be a header row. The custom delimiter must be a single character, e.g. the codec `"csv:\t"` would consume a tab delimited file. |
+| `csv-safe` | Consume structured rows like `csv`, but sends messages with empty maps on failure to parse. Includes row number and parsing errors (if any) in the message's metadata. |
 | `delim:x` | Consume the file in segments divided by a custom delimiter. |
 | `gzip` | Decompress a gzip file, this codec should precede another codec, e.g. `gzip/all-bytes`, `gzip/tar`, `gzip/csv`, etc. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `multipart` | Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch. |
 | `regex:(?m)^\d\d:\d\d:\d\d` | Consume the file in segments divided by regular expression. |
+| `skipbom` | Skip a byte order mark |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 
 

--- a/website/docs/components/inputs/stdin.md
+++ b/website/docs/components/inputs/stdin.md
@@ -70,11 +70,13 @@ Requires version 3.42.0 or newer
 | `chunker:x` | Consume the file in chunks of a given number of bytes. |
 | `csv` | Consume structured rows as comma separated values, the first row must be a header row. |
 | `csv:x` | Consume structured rows as values separated by a custom delimiter, the first row must be a header row. The custom delimiter must be a single character, e.g. the codec `"csv:\t"` would consume a tab delimited file. |
+| `csv-safe` | Consume structured rows like `csv`, but sends messages with empty maps on failure to parse. Includes row number and parsing errors (if any) in the message's metadata. |
 | `delim:x` | Consume the file in segments divided by a custom delimiter. |
 | `gzip` | Decompress a gzip file, this codec should precede another codec, e.g. `gzip/all-bytes`, `gzip/tar`, `gzip/csv`, etc. |
 | `lines` | Consume the file in segments divided by linebreaks. |
 | `multipart` | Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch. |
 | `regex:(?m)^\d\d:\d\d:\d\d` | Consume the file in segments divided by regular expression. |
+| `skipbom` | Skip a byte order mark |
 | `tar` | Parse the file as a tar archive, and consume each file of the archive as a message. |
 
 


### PR DESCRIPTION
update the existing release workflow to authenticate and use `sodahealth/benthos` so we can push our own images